### PR TITLE
fix: 破損データをデコードしないようにするffmpegオプションを追加

### DIFF
--- a/cam_head_tracker/camera.py
+++ b/cam_head_tracker/camera.py
@@ -123,8 +123,10 @@ class VideoCapture:
         cmd = [
             str(FFMPEG_PATH),
             "-hide_banner",
-            "-fflags", "nobuffer", # 入力ストリームの遅延を減らす
-            "-flags", "low_delay", # デコーダーの遅延を減らす
+            "-fflags", "nobuffer", # 入力ストリームの遅延を減らす。
+            "-fflags", "discardcorrupt", # 破損パケットをデコーダーに渡さず破棄する。
+            "-flags", "low_delay", # エンコード／デコードの遅延を減らす。※H.264入力の場合以外では効果はなさそう。
+            "-err_detect", "explode", # デコーダーでデータの破損を検知した際、デコードせず破棄する。
             "-f", "dshow",
             f"-{self._input_format_type}", f"{self._input_format}",
             "-video_size", f"{self._width}x{self._height}",


### PR DESCRIPTION
## 内容
キャプチャするffmpegの引数に以下を追加し、破損データがデコードされないようにする。
* -fflags discardcorrupt  
   破損パケットをデコーダーに渡さず破棄する。
* -err_detect explode  
  デコーダー（libavcodec\mjpegdec.c）でデータの破損を検知した際、デコードせず破棄する。

#5 の事象は `-err_detect explode`だけで解消した。

## 関連 Isuue
close #5 