### PR TITLE
fix: アプリケーション名を修正

### DIFF
--- a/cam_head_tracker/gui.py
+++ b/cam_head_tracker/gui.py
@@ -21,7 +21,7 @@ from cam_head_tracker.tracker import MediapipeTracker, Pose, PoseCorrector
 logger = logging.getLogger(__name__)
 
 
-APP_NAME = "Head Tracker"
+APP_NAME = "CamHeadTracker"
 ICON_FILE_PATH = Path(__file__).parent / "assets/icon.png"
 
 DEFAULT_DISTANCE_SCALE = 1.0


### PR DESCRIPTION
## 概要

アプリケーション名を"Head Tracker"から"CamHeadTracker"に修正しました。

## 詳細

`cam_head_tracker/gui.py`の`APP_NAME`定数を変更しました。この修正により、アプリケーションが正しい名称で表示されるようになります。

## 影響範囲

アプリケーションの名称表示にのみ影響し、機能的な変更はありません。

## 動作確認

起動確認済み。

## 検証方法

アプリケーションを起動し、ウィンドウタイトルまたは表示されるアプリケーション名が"CamHeadTracker"になっていることを確認してください。

## チェックリスト

- [ ] 関連ドキュメントとREADMEを更新した（必要な場合）
- [ ] テストを追加／更新した（必要な場合）
- [ ] 破壊的な変更を記載した（必要な場合）
- [x] テストした
