### PR TITLE
build: bump version to v0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cam-head-tracker"
-version = "0.2.2"
+version = "0.2.3"
 description = "Camera-based head tracking app"
 requires-python = ">=3.13,<3.14"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "cam-head-tracker"
-version = "0.2.2"
+version = "0.2.3"
 source = { virtual = "." }
 dependencies = [
     { name = "mediapipe" },


### PR DESCRIPTION
## Summary

Release v0.2.3

### Changes since v0.2.2

- **Build / Dependencies**:
  - Bump FFmpeg from `n8.0.1` to `n9.0`
  - Bump `softprops/action-gh-release` from 2 to 3
  - Update project dependencies and dev dependencies
- **Docs / Operations**:
  - Introduce Taskfile and update documentation/agent configs
  - Update `NOTICE.txt`
  - Refactor `.editorconfig`